### PR TITLE
Add season hours

### DIFF
--- a/src/firebase.jsx
+++ b/src/firebase.jsx
@@ -43,6 +43,20 @@ export const getAllUsers = async () => {
   return hoursSnap.docs.map((doc) => doc.data());
 }
 
+export const calculateSeasonHours = (user) => {
+  const seasonStart = new Date("1/6/2024");
+  var after = 0;
+
+  user.meetings.forEach((meeting) => {
+      if (new Date(meeting) >= seasonStart) {
+          after++;
+      }
+  });
+
+  var ans = user.hours * after / user.meetings.length;
+  return !ans ? 0 : ans;
+}
+
 export const getRank = (users, user) => {
   let rank = 1;
   users.forEach(u => {

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -8,11 +8,11 @@ import default_user from "../assets/default_user.png"
 import {
     getAllUsers,
     createUser,
+    calculateSeasonHours,
 } from "../firebase";
 import EditUser from "../components/EditUser";
 import Settings from "../components/Settings";
 import Autocomplete from "../components/Autocomplete";
-import { calculateSeasonHours } from "./Home.jsx";
 
 export default function Admin() {
     const [users, setUsers] = useState([]);

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -12,6 +12,7 @@ import {
 import EditUser from "../components/EditUser";
 import Settings from "../components/Settings";
 import Autocomplete from "../components/Autocomplete";
+import { calculateSeasonHours } from "./Home.jsx";
 
 export default function Admin() {
     const [users, setUsers] = useState([]);
@@ -83,6 +84,7 @@ export default function Admin() {
 
                             <div className="statistics">
                                 <p className="stat">Recorded Hours: 0</p>
+                                <p className="stat">Recorded Season Hours: 0</p>
                                 <p className="stat">Volunteer Sessions: 0</p>  
                                 <p className="stat">Meetings Attended: 0</p>
                                 <p className="stat">Graduation Year: {new Date().getFullYear() + 4}</p>
@@ -100,6 +102,7 @@ export default function Admin() {
 
                             <div className="statistics" style={{marginTop: "-10px"}}>
                                 <p className="stat">Recorded Hours: {user.hours}</p>   
+                                <p className="stat">Recorded Season Hours: {Math.round(calculateSeasonHours(user))}</p>   
                                 <p className="stat">Volunteer Sessions: {user.volunteer}</p>   
                                 <p className="stat">Meetings Attended: {user.meetings.length}</p>   
                                 <p className="stat">Graduation Year: {user.graduation}</p>   

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -128,6 +128,7 @@ export default function Home() {
 
                     <div className="statistics">
                         <p className="stat">Your Hours This Season: {user.hours}</p>
+                        <p className="stat">Your Season Hours: { Math.round(calculateSeasonHours(user)) }</p>
                         <p className="stat">Your Meetings Attended: {user.meetings.length}</p>
                         <p className="stat">Your Volunteer Sessions: {user.volunteer}</p>
                         <p className="stat">Your Hours Rank (Out of {users.length}): #{ getRank(users, user) }</p>
@@ -151,4 +152,18 @@ export default function Home() {
             </div>
         </>
     )
+}
+
+export const calculateSeasonHours = (user) => {
+    const seasonStart = new Date("1/6/2024");
+    var after = 0;
+
+    user.meetings.forEach((meeting) => {
+        if (new Date(meeting) >= seasonStart) {
+            after++;
+        }
+    });
+
+    var ans = user.hours * after / user.meetings.length;
+    return !ans ? 0 : ans;
 }

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -9,6 +9,7 @@ import {
     signOut,
     getUserFromUID,
     getMaxHours,
+    calculateSeasonHours,
 } from "../firebase.jsx"
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
@@ -152,18 +153,4 @@ export default function Home() {
             </div>
         </>
     )
-}
-
-export const calculateSeasonHours = (user) => {
-    const seasonStart = new Date("1/6/2024");
-    var after = 0;
-
-    user.meetings.forEach((meeting) => {
-        if (new Date(meeting) >= seasonStart) {
-            after++;
-        }
-    });
-
-    var ans = user.hours * after / user.meetings.length;
-    return !ans ? 0 : ans;
 }

--- a/src/pages/Leaderboard.jsx
+++ b/src/pages/Leaderboard.jsx
@@ -4,6 +4,7 @@ import { useNavigate } from "react-router-dom";
 import { Button, Table } from "react-bootstrap";
 import { useEffect, useState } from "react";
 import { getAllUsers } from "../firebase";
+import { calculateSeasonHours } from "./Home";
 
 export default function Leaderboard() {
     const [users, setUsers] = useState([]);
@@ -50,6 +51,7 @@ export default function Leaderboard() {
                         <th style={{ color: "white", backgroundColor: "black", width: "10%" }}>Rank</th>
                         <th style={{ color: "white", backgroundColor: "black", width: "70%" }}>Name</th>
                         <th style={{ color: "white", backgroundColor: "black", width: "10%" }}>Hours</th>
+                        <th style={{ color: "white", backgroundColor: "black", width: "10%" }}>Season</th>
                         <th style={{ color: "white", backgroundColor: "black", width: "10%" }}>Volunteer</th>
                     </tr>
                 </thead>
@@ -60,6 +62,7 @@ export default function Leaderboard() {
                                 <th className="hours-cell" style={{ color: "white", backgroundColor: "black" }}>{index + 1}</th>
                                 <th className="hours-cell" style={{ color: "white", backgroundColor: "black" }}>{user.name + getRank(index + 1)}</th>
                                 <th className="hours-cell" style={{ color: "white", backgroundColor: "black" }}>{user.hours}</th>
+                                <th className="hours-cell" style={{ color: "white", backgroundColor: "black" }}>{Math.round(calculateSeasonHours(user))}</th>
                                 <th className="hours-cell" style={{ color: "white", backgroundColor: "black" }}>{user.volunteer}</th>
                             </tr>
                         ))

--- a/src/pages/Leaderboard.jsx
+++ b/src/pages/Leaderboard.jsx
@@ -3,8 +3,10 @@ import Header from "../components/Header";
 import { useNavigate } from "react-router-dom";
 import { Button, Table } from "react-bootstrap";
 import { useEffect, useState } from "react";
-import { getAllUsers } from "../firebase";
-import { calculateSeasonHours } from "./Home";
+import { 
+    getAllUsers,
+    calculateSeasonHours ,
+} from "../firebase";
 
 export default function Leaderboard() {
     const [users, setUsers] = useState([]);


### PR DESCRIPTION
Adds season hours to page.

Since each day a user attended doesn't have the hours logged that day tied to it, I multiply the hours times the ratio of days they attended during season. This leads to a decent approximation to what their actual season hours would be.